### PR TITLE
feature: default values in xray map, full :include-raw? column data

### DIFF
--- a/src/donut/dbxray.clj
+++ b/src/donut/dbxray.clj
@@ -129,7 +129,7 @@
   (let [fks (->> (get-foreign-keys dbmd table-name) (group-by :fkcolumn_name))
         pks (->> (get-primary-keys dbmd table-name) (group-by :column_name))
         ixs (->> (get-index-info dbmd table-name)   (group-by :column_name))]
-    (reduce (fn [cols-map {:keys [column_name type_name] :as col}]
+    (reduce (fn [cols-map {:keys [column_name type_name column_def] :as col}]
               (let [raw-column     (assoc col :indexes (get ixs column_name))
                     fk-ref         (some->> (get fks column_name)
                                             first
@@ -138,7 +138,6 @@
                     nullable?      ((:nullable? predicates) raw-column)
                     unique?        ((:unique? predicates) raw-column)
                     autoincrement? ((:autoincrement? predicates) raw-column)
-                    default        (:column_def raw-column)
                     primary-key?   (get pks column_name)]
                 (assoc cols-map
                        (keyword column_name)
@@ -148,7 +147,7 @@
                          primary-key?   (assoc :primary-key? true)
                          unique?        (assoc :unique? true)
                          autoincrement? (assoc :autoincrement? true)
-                         default        (assoc :default default)
+                         column_def     (assoc :default column_def)
                          fk-ref         (assoc :refers-to fk-ref)))))
             {}
             table-cols)))

--- a/src/donut/dbxray.clj
+++ b/src/donut/dbxray.clj
@@ -130,11 +130,8 @@
         pks (->> (get-primary-keys dbmd table-name) (group-by :column_name))
         ixs (->> (get-index-info dbmd table-name)   (group-by :column_name))]
     (reduce (fn [cols-map {:keys [column_name type_name] :as col}]
-              (let [raw-column     (-> (select-keys col [:type_name
-                                                         :column_name
-                                                         :is_nullable
-                                                         :is_autoincrement])
-                                       (assoc :indexes (get ixs column_name)))
+              (prn col)
+              (let [raw-column     (assoc col :indexes (get ixs column_name))
                     fk-ref         (some->> (get fks column_name)
                                             first
                                             ((juxt :pktable_name :pkcolumn_name))
@@ -142,6 +139,7 @@
                     nullable?      ((:nullable? predicates) raw-column)
                     unique?        ((:unique? predicates) raw-column)
                     autoincrement? ((:autoincrement? predicates) raw-column)
+                    default        (:column_def raw-column)
                     primary-key?   (get pks column_name)]
                 (assoc cols-map
                        (keyword column_name)
@@ -151,6 +149,7 @@
                          primary-key?   (assoc :primary-key? true)
                          unique?        (assoc :unique? true)
                          autoincrement? (assoc :autoincrement? true)
+                         default        (assoc :default default)
                          fk-ref         (assoc :refers-to fk-ref)))))
             {}
             table-cols)))

--- a/src/donut/dbxray.clj
+++ b/src/donut/dbxray.clj
@@ -130,7 +130,6 @@
         pks (->> (get-primary-keys dbmd table-name) (group-by :column_name))
         ixs (->> (get-index-info dbmd table-name)   (group-by :column_name))]
     (reduce (fn [cols-map {:keys [column_name type_name] :as col}]
-              (prn col)
               (let [raw-column     (assoc col :indexes (get ixs column_name))
                     fk-ref         (some->> (get fks column_name)
                                             first

--- a/test/donut/dbxray_test.clj
+++ b/test/donut/dbxray_test.clj
@@ -65,7 +65,8 @@
                       :text_ex      {:column-type :text
                                      :nullable?   true}
                       :timestamp_ex {:column-type :timestamp
-                                     :nullable?   true}}
+                                     :nullable?   true
+                                     :default     "CURRENT_TIMESTAMP"}}
                      :column-order
                      [:id :varchar_ex :text_ex :timestamp_ex]}
     :child_records  {:columns
@@ -103,7 +104,7 @@
                         "  id           serial NOT NULL PRIMARY KEY UNIQUE,"
                         "  varchar_ex   varchar(256) NOT NULL UNIQUE,"
                         "  text_ex      text,"
-                        "  timestamp_ex TIMESTAMP NULL"
+                        "  timestamp_ex TIMESTAMP NULL DEFAULT now()"
                         ")")
                    (str "CREATE TABLE child_records ("
                         "  id    integer PRIMARY KEY NOT NULL UNIQUE,"
@@ -129,9 +130,11 @@
                                           :text_ex      {:raw {:type_name   "text"
                                                                :column_name "text_ex"
                                                                :is_nullable "YES"}}
-                                          :timestamp_ex {:raw {:type_name   "timestamp"
-                                                               :column_name "timestamp_ex"
-                                                               :is_nullable "YES"}}}}
+                                          :timestamp_ex {:default    "now()"
+                                                         :raw        {:type_name   "timestamp"
+                                                                      :column_name "timestamp_ex"
+                                                                      :is_nullable "YES"
+                                                                      :column_def  "now()"}}}}
                :child_records  {:columns {:id    {:raw {:type_name   "int4"
                                                         :column_name "id"
                                                         :is_nullable "NO"}}
@@ -154,7 +157,7 @@
                         "  id           integer NOT NULL PRIMARY KEY UNIQUE AUTO_INCREMENT,"
                         "  varchar_ex   varchar(256) NOT NULL UNIQUE,"
                         "  text_ex      text,"
-                        "  timestamp_ex TIMESTAMP NULL"
+                        "  timestamp_ex TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP"
                         ")")
                    (str "CREATE TABLE child_records ("
                         "  id    integer PRIMARY KEY NOT NULL UNIQUE,"
@@ -183,7 +186,8 @@
                                                        :is_nullable "YES"}}
                                   :timestamp_ex {:raw {:type_name   "TIMESTAMP"
                                                        :column_name "timestamp_ex"
-                                                       :is_nullable "YES"}}}}
+                                                       :is_nullable "YES"
+                                                       :column_def  "CURRENT_TIMESTAMP"}}}}
        :child_records  {:columns {:id    {:raw {:type_name   "INT"
                                                 :column_name "id"
                                                 :is_nullable "NO"}}
@@ -202,7 +206,7 @@
         "  id           integer NOT NULL PRIMARY KEY AUTOINCREMENT UNIQUE,"
         "  varchar_ex   varchar(256) NOT NULL UNIQUE,"
         "  text_ex      text,"
-        "  timestamp_ex TIMESTAMP NULL"
+        "  timestamp_ex TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP"
         ")")
    (str "CREATE TABLE child_records ("
         "  id    integer PRIMARY KEY NOT NULL UNIQUE,"
@@ -237,7 +241,8 @@
                                                     :is_nullable "YES"}}
                                :timestamp_ex {:raw {:type_name   "TIMESTAMP"
                                                     :column_name "timestamp_ex"
-                                                    :is_nullable "YES"}}}}
+                                                    :is_nullable "YES"
+                                                    :column_def  "CURRENT_TIMESTAMP"}}}}
     :child_records  {:columns {:id    {:raw {:type_name   "INTEGER"
                                              :column_name "id"
                                              :is_nullable "NO"}}
@@ -263,7 +268,7 @@
                         "  id           integer NOT NULL IDENTITY PRIMARY KEY,"
                         "  varchar_ex   varchar(256) NOT NULL,"
                         "  text_ex      text,"
-                        "  timestamp_ex TIMESTAMP NULL,"
+                        "  timestamp_ex TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,"
                         "  UNIQUE(id),"
                         "  UNIQUE(varchar_ex)"
                         ")")
@@ -304,7 +309,8 @@
                                      :nullable?   true
                                      :raw         {:type_name   "TIMESTAMP"
                                                    :column_name "TIMESTAMP_EX"
-                                                   :is_nullable "YES"}}}}
+                                                   :is_nullable "YES"
+                                                   :column_def  "CURRENT_TIMESTAMP"}}}}
 
            :CHILD_RECORDS
            {:columns {:ID    {:column-type  :integer
@@ -335,7 +341,7 @@
                         "  id           integer IDENTITY PRIMARY KEY,"
                         "  varchar_ex   varchar(256) NOT NULL UNIQUE,"
                         "  text_ex      clob,"
-                        "  timestamp_ex TIMESTAMP NULL"
+                        "  timestamp_ex TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP"
                         ")")
                    (str "CREATE TABLE child_records ("
                         "  id    integer PRIMARY KEY NOT NULL,"
@@ -373,7 +379,8 @@
                                                   :nullable?   true
                                                   :raw         {:type_name   "TIMESTAMP"
                                                                 :column_name "TIMESTAMP_EX"
-                                                                :is_nullable "YES"}}}}
+                                                                :is_nullable "YES"
+                                                                :column_def  "CURRENT_TIMESTAMP"}}}}
         :CHILD_RECORDS  {:columns {:ID    {:column-type  :integer
                                            :primary-key? true
                                            :unique?      true

--- a/test/donut/dbxray_test.clj
+++ b/test/donut/dbxray_test.clj
@@ -41,16 +41,14 @@
          (testing (str "db: " test-db#)
            ~@body)))))
 
-;; Copied verbatim from the defunct clojure-contrib (http://bit.ly/deep-merge-with)
-(defn deep-merge-with [f & maps]
-  (apply
-   (fn m [& maps]
-     (if (every? map? maps)
-       (apply merge-with m maps)
-       (apply f maps)))
-   maps))
-
-(def deep-merge (partial deep-merge-with merge))
+;; Copied verbatim from https://gist.github.com/danielpcox/c70a8aa2c36766200a95
+(defn deep-merge [v & vs]
+  (letfn [(rec-merge [v1 v2]
+            (if (and (map? v1) (map? v2))
+              (merge-with deep-merge v1 v2)
+              v2))]
+    (when (some identity vs)
+      (reduce #(rec-merge %1 %2) v vs))))
 
 (def typical-core-result
   "Most vendors return something that looks like this"
@@ -157,7 +155,7 @@
                         "  id           integer NOT NULL PRIMARY KEY UNIQUE AUTO_INCREMENT,"
                         "  varchar_ex   varchar(256) NOT NULL UNIQUE,"
                         "  text_ex      text,"
-                        "  timestamp_ex TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP"
+                        "  timestamp_ex TIMESTAMP DEFAULT CURRENT_TIMESTAMP NULL"
                         ")")
                    (str "CREATE TABLE child_records ("
                         "  id    integer PRIMARY KEY NOT NULL UNIQUE,"
@@ -341,7 +339,7 @@
                         "  id           integer IDENTITY PRIMARY KEY,"
                         "  varchar_ex   varchar(256) NOT NULL UNIQUE,"
                         "  text_ex      clob,"
-                        "  timestamp_ex TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP"
+                        "  timestamp_ex TIMESTAMP DEFAULT CURRENT_TIMESTAMP NULL"
                         ")")
                    (str "CREATE TABLE child_records ("
                         "  id    integer PRIMARY KEY NOT NULL,"

--- a/test/donut/dbxray_test.clj
+++ b/test/donut/dbxray_test.clj
@@ -41,14 +41,16 @@
          (testing (str "db: " test-db#)
            ~@body)))))
 
-;; Copied verbatim from https://gist.github.com/danielpcox/c70a8aa2c36766200a95
-(defn deep-merge [v & vs]
-  (letfn [(rec-merge [v1 v2]
-            (if (and (map? v1) (map? v2))
-              (merge-with deep-merge v1 v2)
-              v2))]
-    (when (some identity vs)
-      (reduce #(rec-merge %1 %2) v vs))))
+;; Copied verbatim from the defunct clojure-contrib (http://bit.ly/deep-merge-with)
+(defn deep-merge-with [f & maps]
+  (apply
+   (fn m [& maps]
+     (if (every? map? maps)
+       (apply merge-with m maps)
+       (apply f maps)))
+   maps))
+
+(def deep-merge (partial deep-merge-with merge))
 
 (def typical-core-result
   "Most vendors return something that looks like this"
@@ -102,7 +104,7 @@
                         "  id           serial NOT NULL PRIMARY KEY UNIQUE,"
                         "  varchar_ex   varchar(256) NOT NULL UNIQUE,"
                         "  text_ex      text,"
-                        "  timestamp_ex TIMESTAMP NULL DEFAULT now()"
+                        "  timestamp_ex TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP"
                         ")")
                    (str "CREATE TABLE child_records ("
                         "  id    integer PRIMARY KEY NOT NULL UNIQUE,"
@@ -128,11 +130,10 @@
                                           :text_ex      {:raw {:type_name   "text"
                                                                :column_name "text_ex"
                                                                :is_nullable "YES"}}
-                                          :timestamp_ex {:default    "now()"
-                                                         :raw        {:type_name   "timestamp"
+                                          :timestamp_ex {:raw        {:type_name   "timestamp"
                                                                       :column_name "timestamp_ex"
                                                                       :is_nullable "YES"
-                                                                      :column_def  "now()"}}}}
+                                                                      :column_def  "CURRENT_TIMESTAMP"}}}}
                :child_records  {:columns {:id    {:raw {:type_name   "int4"
                                                         :column_name "id"
                                                         :is_nullable "NO"}}


### PR DESCRIPTION
This PR does two things, so let me know if you'd like to break it up:

1. Adds :default key from COLUMN_DEF when present. Addresses https://github.com/donut-party/dbxray/issues/10 partially, I think
2. When `include-raw?` is true, returns the full column data. This is useful for people wishing to use any keys unsupported by xray